### PR TITLE
PROJFBPRO-64 Hotfix Update status

### DIFF
--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -12,36 +12,21 @@ def update_mitigation_status(event, token, satisfied_mitigations=None, unsatisfi
     if satisfied_mitigations is not None:
         vuln_status = "NOT_VULNERABLE" if satisfied_mitigations else "VULNERABLE"
 
-    # Gather all fields to be updated
-    updated_fields = {}
-
+    # Update fields
     # Estimated vulnerability of the system
     if vuln_status is not None:
-        updated_fields.update({
-            "vulnerability_status": vuln_status
-        })
+        event["hardening_info"]['vulnerability_status'] = vuln_status
 
-    # Mitigations for which all mapped rules are (not) present on the system
+    # Mitigations for which (not) all mapped rules are present on the system,
     # including descriptions for each mitigation and rule
     if satisfied_mitigations is not None:
-        updated_fields.update({
-            "satisfied_mitigations": satisfied_mitigations
-        })
+        event["hardening_info"]['satisfied_mitigations'] = satisfied_mitigations
     if unsatisfied_mitigations is not None:
-        updated_fields.update({
-            "unsatisfied_mitigations": unsatisfied_mitigations
-        })
+        event["hardening_info"]['unsatisfied_mitigations'] = unsatisfied_mitigations
 
     # Additional information about errors that occurred during lookup
     if error_message is not None:
-        updated_fields.update({
-            "error_message": error_message
-        })
-
-    # Update fields in event
-    event.update({
-        "hardening_info": updated_fields
-    })
+        event["hardening_info"]['error_message'] = error_message
 
 
 def add_rule_titles(mitigations, token):

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -1,7 +1,7 @@
 from src.ea_rest_template import ea_rest_call
 
 
-def update_mitigation_status(event, token, satisfied_mitigations=None, unsatisfied_mitigations=None, error_message=None):
+def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsatisfied_mitigations=None, error_message=None):
     # If EA reachable, get rule titles and add them as additional info
     if token:
         try:

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -8,7 +8,7 @@ def update_mitigation_status(event, token, satisfied_mitigations=None, unsatisfi
             add_rule_titles(satisfied_mitigations, token)
             add_rule_titles(unsatisfied_mitigations, token)
         # Titles serve only as additional information. If anything goes wrong due to EA, ignore and just update fields
-        except:
+        except Exception:
             pass
 
     # Reevaluate vulnerability status if satisfied mitigations is being updated

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -1,7 +1,8 @@
 from src.ea_rest_template import ea_rest_call
 
 
-def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsatisfied_mitigations=None, error_message=None):
+def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsatisfied_mitigations=None,
+                             error_message=None):
     # If EA reachable, get rule titles and add them as additional info
     if token:
         try:

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -4,8 +4,12 @@ from src.ea_rest_template import ea_rest_call
 def update_mitigation_status(event, token, satisfied_mitigations=None, unsatisfied_mitigations=None, error_message=None):
     # If EA reachable, get rule titles and add them as additional info
     if token:
-        add_rule_titles(satisfied_mitigations, token)
-        add_rule_titles(unsatisfied_mitigations, token)
+        try:
+            add_rule_titles(satisfied_mitigations, token)
+            add_rule_titles(unsatisfied_mitigations, token)
+        # Titles serve only as additional information. If anything goes wrong due to EA, ignore and just update fields
+        except:
+            pass
 
     # Reevaluate vulnerability status if satisfied mitigations is being updated
     vuln_status = None

--- a/test/TestUpdateMitigationStatus.py
+++ b/test/TestUpdateMitigationStatus.py
@@ -23,6 +23,22 @@ class TestAddMitigationStatus(unittest.TestCase):
         credentials = get_credentials()
         token = get_jwt_token(credentials['username'], credentials['password'])
 
+        # Default initialization
+        self.data_1.update({
+            "hardening_info": {
+                # Mitigations for which all mapped rules are (not) present on the system
+                # including descriptions for each mitigation and rule
+                "satisfied_mitigations": {},
+                "unsatisfied_mitigations": {},
+
+                # Estimated vulnerability of the system
+                "vulnerability_status": "VULNERABLE",
+
+                # Additional information about errors that occurred during lookup
+                "error_message": None
+            }
+        })
+
         hardening_info = {
             "satisfied_mitigations": {
                 "M1040": {
@@ -36,6 +52,7 @@ class TestAddMitigationStatus(unittest.TestCase):
             },
             "unsatisfied_mitigations": {},
             "vulnerability_status": "NOT_VULNERABLE",
+            "error_message": None
         }
 
         satisfied_mitigations = {


### PR DESCRIPTION
While batch updating the fields, any fields that weren't supposed to be updated got deleted because the whole "hardening_info" field was simply overridden. Now every field gets updated individually.

Also surrounded add_rule_titles with broad try/except, because it is just nice-to-have information that, if something goes wrong, shouldn't prevent the important information from being updated.