### PR TITLE
PROJFBPRO-68 Add partial mitigation support

### DIFF
--- a/assets/mapping.json
+++ b/assets/mapping.json
@@ -59,16 +59,6 @@
           "rules": [
             1606
           ]
-        },
-        "M1054": {
-          "description": "For the Office Test method, create the Registry key used to execute it and set the permissions to \"Read Control\" to prevent easy access to the key without administrator permissions or requiring Privilege Escalation.",
-          "rules": [
-          ]
-        },
-        "M1051": {
-          "description": "For the Outlook methods, blocking macros may be ineffective as the Visual Basic engine used for these features is separate from the macro scripting engine. Microsoft has released patches to try to address each issue. Ensure KB3191938 which blocks Outlook Visual Basic and displays a malicious code warning, KB4011091 which disables custom forms by default, and KB4011162 which removes the legacy Home Page feature, are applied to systems.",
-          "rules": [
-          ]
         }
       }
     },
@@ -102,29 +92,19 @@
             1605,
             1612
           ]
-        },
-        "M1054": {
-          "description": "For the Office Test method, create the Registry key used to execute it and set the permissions to \"Read Control\" to prevent easy access to the key without administrator permissions or requiring Privilege Escalation.",
-          "rules": [
-          ]
         }
-      },
-      "T1137.03": {
-        "mitigations": {
-          "M1040": {
-            "partial": false,
-            "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
-            "rules": [
-              1604,
-              1605,
-              1612
-            ]
-          },
-          "M1051": {
-            "description": "For the Outlook methods, blocking macros may be ineffective as the Visual Basic engine used for these features is separate from the macro scripting engine. Microsoft has released patches to try to address each issue. Ensure KB3191938 which blocks Outlook Visual Basic and displays a malicious code warning, KB4011091 which disables custom forms by default, and KB4011162 which removes the legacy Home Page feature, are applied to systems.",
-            "rules": [
-            ]
-          }
+      }
+    },
+    "T1137.03": {
+      "mitigations": {
+        "M1040": {
+          "partial": false,
+          "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
+          "rules": [
+            1604,
+            1605,
+            1612
+          ]
         }
       }
     },
@@ -138,11 +118,6 @@
             1605,
             1612
           ]
-        },
-        "M1051": {
-          "description": "For the Outlook methods, blocking macros may be ineffective as the Visual Basic engine used for these features is separate from the macro scripting engine. Microsoft has released patches to try to address each issue. Ensure KB3191938 which blocks Outlook Visual Basic and displays a malicious code warning, KB4011091 which disables custom forms by default, and KB4011162 which removes the legacy Home Page feature, are applied to systems.",
-          "rules": [
-          ]
         }
       }
     },
@@ -155,11 +130,6 @@
             1604,
             1605,
             1612
-          ]
-        },
-        "M1051": {
-          "description": "For the Outlook methods, blocking macros may be ineffective as the Visual Basic engine used for these features is separate from the macro scripting engine. Microsoft has released patches to try to address each issue. Ensure KB3191938 which blocks Outlook Visual Basic and displays a malicious code warning, KB4011091 which disables custom forms by default, and KB4011162 which removes the legacy Home Page feature, are applied to systems.",
-          "rules": [
           ]
         }
       }

--- a/assets/mapping.json
+++ b/assets/mapping.json
@@ -3,6 +3,7 @@
     "T1040": {
       "mitigations": {
         "M1041": {
+          "partial": true,
           "description": "Ensure that all wired and/or wireless traffic is encrypted appropriately using authentification protocols",
           "rules": [
             1995,
@@ -10,6 +11,7 @@
           ]
         },
         "M1030": {
+          "partial": true,
           "description": "Deny direct access of broadcasts and multicast sniffing",
           "rules": [
             4432,
@@ -21,6 +23,7 @@
     "T1059.007": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Visual Basic and JavaScript scripts from executing potentially malicious downloaded content.",
           "rules": [
             1608
@@ -31,6 +34,7 @@
     "T1059.005": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Visual Basic and JavaScript scripts from executing potentially malicious downloaded content.",
           "rules": [
             1608
@@ -41,6 +45,7 @@
     "T1137": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -49,6 +54,7 @@
           ]
         },
         "M1042": {
+          "partial": true,
           "description": "Follow Office macro security best practices suitable for your environment. Disable Office VBA macros from executing.\n\nDisable Office add-ins. If they are required, follow best practices for securing them by requiring them to be signed and disabling user notification for allowing add-ins. For some add-ins types (WLL, VBA) additional mitigation is likely required as disabling add-ins in the Office Trust Center does not disable WLL nor does it prevent VBA code from executing.",
           "rules": [
             1606
@@ -69,6 +75,7 @@
     "T1137.01": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -77,6 +84,7 @@
           ]
         },
         "M1042": {
+          "partial": true,
           "description": "Follow Office macro security best practices suitable for your environment. Disable Office VBA macros from executing.\n\nDisable Office add-ins. If they are required, follow best practices for securing them by requiring them to be signed and disabling user notification for allowing add-ins. For some add-ins types (WLL, VBA) additional mitigation is likely required as disabling add-ins in the Office Trust Center does not disable WLL nor does it prevent VBA code from executing.",
           "rules": [
             1606
@@ -87,6 +95,7 @@
     "T1137.02": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -103,6 +112,7 @@
       "T1137.03": {
         "mitigations": {
           "M1040": {
+            "partial": false,
             "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
             "rules": [
               1604,
@@ -121,6 +131,7 @@
     "T1137.04": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -138,6 +149,7 @@
     "T1137.05": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -155,6 +167,7 @@
     "T1137.06": {
       "mitigations": {
         "M1040": {
+          "partial": false,
           "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Office applications from creating child processes and from writing potentially malicious executable content to disk.",
           "rules": [
             1604,
@@ -189,6 +202,7 @@
     "T1566": {
       "mitigations": {
         "M1049": {
+          "partial": true,
           "description": "Anti-virus can automatically quarantine suspicious files.",
           "rules": [
             4312

--- a/assets/mapping.json
+++ b/assets/mapping.json
@@ -164,6 +164,28 @@
         }
       }
     },
+    "T1557.001": {
+      "mitigations": {
+        "M1042": {
+          "partial": true,
+          "description": "Disable LLMNR and NetBIOS in local computer security settings or by group policy if they are not needed within an environment.",
+          "rules": [
+            4432,
+            4453
+          ]
+        },
+        "M1037": {
+          "partial": true,
+          "description": "Use host-based security software to block LLMNR/NetBIOS traffic. Enabling SMB Signing can stop NTLMv2 relay attacks.",
+          "rules": [
+            4613,
+            4614,
+            4617,
+            4618
+          ]
+        }
+      }
+    },
     "T1566": {
       "mitigations": {
         "M1049": {

--- a/assets/mapping.json
+++ b/assets/mapping.json
@@ -9,7 +9,7 @@
             1996
           ]
         },
-	    "M1030": {
+        "M1030": {
           "description": "Deny direct access of broadcasts and multicast sniffing",
           "rules": [
             4432,

--- a/src/check_mapping.py
+++ b/src/check_mapping.py
@@ -1,6 +1,14 @@
-import json
-
-
+# Logic for whether a mitigation is considered satisfied, partial, or unsatisfied
+# "Partial" refers to the value of the "partial" field in the mapping for that mitigation
+# -------------------------------------------
+# | Partial | Rules present | Result        |
+# |  False  |      ALL      |  SATISFIED    |
+# |  False  |      SOME     |  PARTIAL      |
+# |  False  |      NONE     |  UNSATISFIED  |
+# |  True   |      ALL      |  PARTIAL      |
+# |  True   |      SOME     |  PARTIAL      |
+# |  True   |      NONE     |  UNSATISFIED  |
+# -------------------------------------------
 def check_mapping(mitigations, rule_ids):
     satisfied_mitigations = {}
     partial_mitigations = {}

--- a/src/check_mapping.py
+++ b/src/check_mapping.py
@@ -20,7 +20,7 @@ def check_mapping(mitigations, rule_ids):
 
         # ALL rules in mitigation are present
         if all(_id in rule_ids for _id in rules):
-            # Add mitigation to list (partial_mitigations if it is tagged partial)
+            # Add mitigation to dict (partial_mitigations if it is tagged partial)
             if partial:
                 partial_mitigations[mitigation_id] = mitigations[mitigation_id]
             else:
@@ -32,7 +32,7 @@ def check_mapping(mitigations, rule_ids):
             rules_present = [_id in rule_ids for _id in rules]
             rules_not_present = [_id not in rule_ids for _id in rules]
 
-            # Add mitigation to list
+            # Add mitigation to dict
             partial_mitigations[mitigation_id] = mitigations[mitigation_id]
 
             # Update 'rules' field with separated lists
@@ -43,7 +43,7 @@ def check_mapping(mitigations, rule_ids):
 
         # NO rule in mitigation is present
         else:
-            # Add mitigation to list
+            # Add mitigation to dict
             unsatisfied_mitigations[mitigation_id] = mitigations[mitigation_id]
 
     return satisfied_mitigations, partial_mitigations, unsatisfied_mitigations

--- a/src/check_mapping.py
+++ b/src/check_mapping.py
@@ -3,13 +3,39 @@ import json
 
 def check_mapping(mitigations, rule_ids):
     satisfied_mitigations = {}
+    partial_mitigations = {}
     unsatisfied_mitigations = {}
 
     for mitigation_id in mitigations:
+        partial = mitigations[mitigation_id]['partial']
         rules = mitigations[mitigation_id]['rules']
-        if all(_id in rule_ids for _id in rules):
-            satisfied_mitigations.update({mitigation_id: mitigations[mitigation_id]})
-        else:
-            unsatisfied_mitigations.update({mitigation_id: mitigations[mitigation_id]})
 
-    return satisfied_mitigations, unsatisfied_mitigations
+        # ALL rules in mitigation are present
+        if all(_id in rule_ids for _id in rules):
+            # Add mitigation to list (partial_mitigations if it is tagged partial)
+            if partial:
+                partial_mitigations[mitigation_id] = mitigations[mitigation_id]
+            else:
+                satisfied_mitigations[mitigation_id] = mitigations[mitigation_id]
+
+        # ANY rule in mitigation is present
+        elif any(_id in rule_ids for _id in rules):
+            # Separate rules that are present/not present
+            rules_present = [_id in rule_ids for _id in rules]
+            rules_not_present = [_id not in rule_ids for _id in rules]
+
+            # Add mitigation to list
+            partial_mitigations[mitigation_id] = mitigations[mitigation_id]
+
+            # Update 'rules' field with separated lists
+            partial_mitigations[mitigation_id]['rules'] = {
+                "present": rules_present,
+                "not_present": rules_not_present
+            }
+
+        # NO rule in mitigation is present
+        else:
+            # Add mitigation to list
+            unsatisfied_mitigations[mitigation_id] = mitigations[mitigation_id]
+
+    return satisfied_mitigations, partial_mitigations, unsatisfied_mitigations

--- a/src/handle_data.py
+++ b/src/handle_data.py
@@ -78,7 +78,7 @@ def handle_data(event):
         hardening_id = get_hardening_id(token, variation_key)
         rules = get_rule_ids(token, hardening_id)
 
-        # Check mapping for which mitigations are (un)satisfied
+        # Check mapping for which mitigations are (not/partially) satisfied
         satisfied_mitigations, partial_mitigations, unsatisfied_mitigations = check_mapping(mitigations, rules)
 
     # Catch any exception and save its message to include in the output event

--- a/src/handle_data.py
+++ b/src/handle_data.py
@@ -68,10 +68,10 @@ def handle_data(event):
         ea_system_id = get_ea_system_id_from_list_of_systems(systems, mdr_name)
 
         # Check whether system is InState
-        # state = get_the_state(token, ea_system_id)
-        # if not state:
-        #     update_mitigation_status(event, error_message="System is not in state")
-        #     return event
+        state = get_the_state(token, ea_system_id)
+        if not state:
+            update_mitigation_status(event, error_message="System is not in state")
+            return event
 
         # Get all hardening rules applied on this system
         variation_key = get_hardening_variation_key_by_id(token, ea_system_id)

--- a/src/handle_data.py
+++ b/src/handle_data.py
@@ -25,6 +25,7 @@ def handle_data(event):
                 # Mitigations for which all mapped rules are (not) present on the system
                 # including descriptions for each mitigation and rule
                 "satisfied_mitigations": {},
+                "partial_mitigations": {},
                 "unsatisfied_mitigations": {},
 
                 # Estimated vulnerability of the system
@@ -49,6 +50,7 @@ def handle_data(event):
     # Initialize variables
     token = None
     satisfied_mitigations = None
+    partial_mitigations = None
     unsatisfied_mitigations = None
     error_message = None
 
@@ -66,10 +68,10 @@ def handle_data(event):
         ea_system_id = get_ea_system_id_from_list_of_systems(systems, mdr_name)
 
         # Check whether system is InState
-        state = get_the_state(token, ea_system_id)
-        if not state:
-            update_mitigation_status(event, error_message="System is not in state")
-            return event
+        # state = get_the_state(token, ea_system_id)
+        # if not state:
+        #     update_mitigation_status(event, error_message="System is not in state")
+        #     return event
 
         # Get all hardening rules applied on this system
         variation_key = get_hardening_variation_key_by_id(token, ea_system_id)
@@ -77,7 +79,7 @@ def handle_data(event):
         rules = get_rule_ids(token, hardening_id)
 
         # Check mapping for which mitigations are (un)satisfied
-        satisfied_mitigations, unsatisfied_mitigations = check_mapping(attack_id, rules)
+        satisfied_mitigations, partial_mitigations, unsatisfied_mitigations = check_mapping(mitigations, rules)
 
     # Catch any exception and save its message to include in the output event
     except Exception as e:
@@ -85,6 +87,7 @@ def handle_data(event):
             error_message = e.args[0]
 
     # Update event with gathered information
-    update_mitigation_status(token, event, satisfied_mitigations, unsatisfied_mitigations, error_message)
+    update_mitigation_status(event, token, satisfied_mitigations, partial_mitigations, unsatisfied_mitigations,
+                             error_message)
 
     return event

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -1,13 +1,18 @@
 from src.ea_rest_template import ea_rest_call
 
 
-def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsatisfied_mitigations=None,
-                             error_message=None):
+def update_mitigation_status(event, token=None, _satisfied_mitigations=None, _partial_mitigations=None,
+                             _unsatisfied_mitigations=None, error_message=None):
+    satisfied_mitigations = _satisfied_mitigations.copy()
+    partial_mitigations = _partial_mitigations.copy()
+    unsatisfied_mitigations = _unsatisfied_mitigations.copy()
+
     # If EA reachable, get rule titles and add them as additional info
     if token:
         try:
-            add_rule_titles(satisfied_mitigations, token)
-            add_rule_titles(unsatisfied_mitigations, token)
+            add_rule_titles(satisfied_mitigations, False, token)
+            add_rule_titles(partial_mitigations, True, token)
+            add_rule_titles(unsatisfied_mitigations, False, token)
         # Titles serve only as additional information. If anything goes wrong due to EA, ignore and just update fields
         except Exception:
             pass
@@ -22,10 +27,12 @@ def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsa
     if vuln_status is not None:
         event["hardening_info"]['vulnerability_status'] = vuln_status
 
-    # Mitigations for which (not) all mapped rules are present on the system,
+    # Mitigations for which all/some/none mapped rules are present on the system,
     # including descriptions for each mitigation and rule
     if satisfied_mitigations is not None:
         event["hardening_info"]['satisfied_mitigations'] = satisfied_mitigations
+    if partial_mitigations is not None:
+        event["hardening_info"]['partial_mitigations'] = partial_mitigations
     if unsatisfied_mitigations is not None:
         event["hardening_info"]['unsatisfied_mitigations'] = unsatisfied_mitigations
 
@@ -34,20 +41,29 @@ def update_mitigation_status(event, token=None, satisfied_mitigations=None, unsa
         event["hardening_info"]['error_message'] = error_message
 
 
-def add_rule_titles(mitigations, token):
+def add_rule_titles(mitigations, partial, token):
     if not mitigations:
         return
 
-    updated_rules = {}
-    for mitigation in mitigations:
-        for rule in mitigations[mitigation]['rules']:
-            response = ea_rest_call(f'/api/v3/benchmarkengine/Rules/{rule}', 'GET', token)
-            updated_rules.update({
-                rule: {
-                    'title': response['title']
-                }
-            })
+    if partial:
+        updated_rules = {
+            'present': {},
+            'not_present': {}
+        }
+        for mitigation in mitigations:
+            for rule in mitigations[mitigation]['rules']['present']:
+                updated_rules['present'][rule] = {'title': get_rule_title(rule, token)}
+            for rule in mitigations[mitigation]['rules']['not_present']:
+                updated_rules['not_present'][rule] = {'title': get_rule_title(rule, token)}
+            mitigations[mitigation]['rules'] = updated_rules
+    else:
+        updated_rules = {}
+        for mitigation in mitigations:
+            for rule in mitigations[mitigation]['rules']:
+                updated_rules[rule] = {'title': get_rule_title(rule, token)}
+            mitigations[mitigation]['rules'] = updated_rules
 
-        mitigations[mitigation].update({
-            "rules": updated_rules
-        })
+
+def get_rule_title(rule, token):
+    response = ea_rest_call(f'/api/v3/benchmarkengine/Rules/{rule}', 'GET', token)
+    return response['title']

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -1,11 +1,19 @@
 from src.ea_rest_template import ea_rest_call
 
 
-def update_mitigation_status(event, token=None, _satisfied_mitigations=None, _partial_mitigations=None,
-                             _unsatisfied_mitigations=None, error_message=None):
-    satisfied_mitigations = _satisfied_mitigations.copy()
-    partial_mitigations = _partial_mitigations.copy()
-    unsatisfied_mitigations = _unsatisfied_mitigations.copy()
+def update_mitigation_status(event, token=None, satisfied_mitigations=None, partial_mitigations=None,
+                             unsatisfied_mitigations=None, error_message=None):
+    _satisfied_mitigations = None
+    _partial_mitigations = None
+    _unsatisfied_mitigations = None
+
+    # Copy dicts
+    if satisfied_mitigations is not None:
+        _satisfied_mitigations = satisfied_mitigations.copy()
+    if partial_mitigations is not None:
+        _partial_mitigations = partial_mitigations.copy()
+    if unsatisfied_mitigations is not None:
+        _unsatisfied_mitigations = unsatisfied_mitigations.copy()
 
     # If EA reachable, get rule titles and add them as additional info
     if token:

--- a/src/update_mitigation_status.py
+++ b/src/update_mitigation_status.py
@@ -25,24 +25,25 @@ def update_mitigation_status(event, token=None, satisfied_mitigations=None, part
         except Exception:
             pass
 
-    # Reevaluate vulnerability status if satisfied mitigations is being updated
-    vuln_status = None
-    if satisfied_mitigations is not None:
-        vuln_status = "NOT_VULNERABLE" if satisfied_mitigations else "VULNERABLE"
-
     # Update fields
-    # Estimated vulnerability of the system
-    if vuln_status is not None:
-        event["hardening_info"]['vulnerability_status'] = vuln_status
-
     # Mitigations for which all/some/none mapped rules are present on the system,
     # including descriptions for each mitigation and rule
-    if satisfied_mitigations is not None:
-        event["hardening_info"]['satisfied_mitigations'] = satisfied_mitigations
-    if partial_mitigations is not None:
-        event["hardening_info"]['partial_mitigations'] = partial_mitigations
-    if unsatisfied_mitigations is not None:
-        event["hardening_info"]['unsatisfied_mitigations'] = unsatisfied_mitigations
+    if _satisfied_mitigations is not None:
+        event["hardening_info"]['satisfied_mitigations'] = _satisfied_mitigations
+    if _partial_mitigations is not None:
+        event["hardening_info"]['partial_mitigations'] = _partial_mitigations
+    if _unsatisfied_mitigations is not None:
+        event["hardening_info"]['unsatisfied_mitigations'] = _unsatisfied_mitigations
+
+    # Reevaluate vulnerability status
+    if event["hardening_info"]['satisfied_mitigations']:
+        vuln_status = "NOT_VULNERABLE"
+    elif event["hardening_info"]['partial_mitigations']:
+        vuln_status = "PARTIALLY_VULNERABLE"
+    else:
+        vuln_status = "VULNERABLE"
+    # Estimated vulnerability of the system
+    event["hardening_info"]['vulnerability_status'] = vuln_status
 
     # Additional information about errors that occurred during lookup
     if error_message is not None:

--- a/test/TestCheckMapping.py
+++ b/test/TestCheckMapping.py
@@ -21,15 +21,15 @@ class TestCheckMapping(unittest.TestCase):
             4275, 4276, 4277, 4278, 4279, 4280, 4281,
         ]
 
-        # -------------------------------------
-        # | Partial | Present | Result        |
-        # |  False  |  ALL    |  SATISFIED    |
-        # |  False  |  SOME   |  PARTIAL      |
-        # |  False  |  NONE   |  UNSATISFIED  |
-        # |  True   |  ALL    |  PARTIAL      |
-        # |  True   |  SOME   |  PARTIAL      |
-        # |  True   |  NONE   |  UNSATISFIED  |
-        # -------------------------------------
+        # -------------------------------------------
+        # | Partial | Rules present | Result        |
+        # |  False  |      ALL      |  SATISFIED    |
+        # |  False  |      SOME     |  PARTIAL      |
+        # |  False  |      NONE     |  UNSATISFIED  |
+        # |  True   |      ALL      |  PARTIAL      |
+        # |  True   |      SOME     |  PARTIAL      |
+        # |  True   |      NONE     |  UNSATISFIED  |
+        # -------------------------------------------
         mitigations = {
             # Partial False, ALL rules present
             "M1040": {

--- a/test/TestCheckMapping.py
+++ b/test/TestCheckMapping.py
@@ -21,25 +21,79 @@ class TestCheckMapping(unittest.TestCase):
             4275, 4276, 4277, 4278, 4279, 4280, 4281,
         ]
 
+        # -------------------------------------
+        # | Partial | Present | Result        |
+        # |  False  |  ALL    |  SATISFIED    |
+        # |  False  |  SOME   |  PARTIAL      |
+        # |  False  |  NONE   |  UNSATISFIED  |
+        # |  True   |  ALL    |  PARTIAL      |
+        # |  True   |  SOME   |  PARTIAL      |
+        # |  True   |  NONE   |  UNSATISFIED  |
+        # -------------------------------------
         mitigations = {
-                "M1040": {
-                    "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Visual" +
-                    " Basic and JavaScript scripts from executing potentially malicious downloaded content.",
-                    "rules": [
-                        1608
-                    ]
-                }
+            # Partial False, ALL rules present
+            "M1040": {
+                "partial": False,
+                "description": "On Windows 10, enable Attack Surface Reduction (ASR) rules to prevent Visual" +
+                " Basic and JavaScript scripts from executing potentially malicious downloaded content.",
+                "rules": [
+                    1608
+                ]
+            },
+            # Partial False, SOME rules present
+            "M1041": {
+                "partial": False,
+                "description": "Test",
+                "rules": [
+                    1608,
+                    4822
+                ]
+            },
+            # Partial False, NO rules present
+            "M1042": {
+                "partial": False,
+                "description": "Test",
+                "rules": [
+                    11,
+                    12
+                ]
+            },
+            # Partial True, ALL rules present
+            "M1043": {
+                "partial": True,
+                "description": "Test",
+                "rules": [
+                    82,
+                    83
+                ]
+            },
+            # Partial True, SOME rules present
+            "M1044": {
+                "partial": True,
+                "description": "Test",
+                "rules": [
+                    44,
+                    82
+                ]
+            },
+            # Partial True, NO rules present
+            "M1045": {
+                "partial": True,
+                "description": "Test",
+                "rules": [
+                    10,
+                    20
+                ]
+            }
         }
 
-        satisfied_mitigations, unsatisfied_mitigations = check_mapping(mitigations, rule_ids)
-        self.assertEqual(['M1040'], list(satisfied_mitigations.keys()), "Mitigations not correctly detected")
-        self.assertEqual([], list(unsatisfied_mitigations.keys()), "Mitigations not correctly detected")
-
-        rule_ids = [5, 10, 20]
-
-        satisfied_mitigations, unsatisfied_mitigations = check_mapping(mitigations, rule_ids)
-        self.assertEqual([], list(satisfied_mitigations.keys()), "Mitigations not correctly detected")
-        self.assertEqual(['M1040'], list(unsatisfied_mitigations.keys()), "Mitigations not correctly detected")
+        satisfied_mitigations, partial_mitigations, unsatisfied_mitigations = check_mapping(mitigations, rule_ids)
+        self.assertEqual(['M1040'], list(satisfied_mitigations.keys()),
+                         "Mitigations not correctly detected")
+        self.assertEqual(['M1041', 'M1043', 'M1044'], list(partial_mitigations.keys()),
+                         "Mitigations not correctly detected")
+        self.assertEqual(['M1042', 'M1045'], list(unsatisfied_mitigations.keys()),
+                         "Mitigations not correctly detected")
 
 
 if __name__ == '__main__':

--- a/test/TestUpdateMitigationStatus.py
+++ b/test/TestUpdateMitigationStatus.py
@@ -19,7 +19,7 @@ class TestAddMitigationStatus(unittest.TestCase):
         self.json_file_1.close()
         print("\nEnding Unittest\n")
 
-    def test_add_mitigation_status(self):
+    def test_update_mitigation_status(self):
         credentials = get_credentials()
         token = get_jwt_token(credentials['username'], credentials['password'])
 
@@ -29,6 +29,7 @@ class TestAddMitigationStatus(unittest.TestCase):
                 # Mitigations for which all mapped rules are (not) present on the system
                 # including descriptions for each mitigation and rule
                 "satisfied_mitigations": {},
+                "partial_mitigations": {},
                 "unsatisfied_mitigations": {},
 
                 # Estimated vulnerability of the system
@@ -50,6 +51,23 @@ class TestAddMitigationStatus(unittest.TestCase):
                     }
                 }
             },
+            "partial_mitigations": {
+                "M1041": {
+                    "description": "Test",
+                    "rules": {
+                        'present': {
+                            1608: {
+                                "title": "(L1) Ensure 'Configure Attack Surface Reduction rules: Block JavaScript or VBScript from launching downloaded executable content'"
+                            }
+                        },
+                        'not_present': {
+                            1608: {
+                                "title": "(L1) Ensure 'Configure Attack Surface Reduction rules: Block JavaScript or VBScript from launching downloaded executable content'"
+                            }
+                        }
+                    }
+                }
+            },
             "unsatisfied_mitigations": {},
             "vulnerability_status": "NOT_VULNERABLE",
             "error_message": None
@@ -61,9 +79,18 @@ class TestAddMitigationStatus(unittest.TestCase):
                 'rules': [1608]
             }
         }
+        partial_mitigations = {
+            'M1041': {
+                "description": "Test",
+                'rules': {
+                    'present': [1608],
+                    'not_present': [1608]
+                }
+            }
+        }
         unsatisfied_mitigations = {}
 
-        update_mitigation_status(self.data_1, token, satisfied_mitigations, unsatisfied_mitigations)
+        update_mitigation_status(self.data_1, token, satisfied_mitigations, partial_mitigations, unsatisfied_mitigations)
 
         rules = self.data_1['hardening_info']['satisfied_mitigations']['M1040']['rules']
         self.assertTrue(all(rules[rule]['title'] for rule in rules), "Missing titles")


### PR DESCRIPTION
In the mapping, "partial" indicates whether a mapping for a mitigation only partially mitigates the technique.
In the code, after checking the mapping a mitigation considered to be a "partial_mitigation" can be one of 2 things:

1. A mitigation tagged as "partial" with at least one rule present
2. A mitigation not tagged as "partial" with at least one, but not all rules present

both have the same effect on the vulnerability: only partially securing the system.

The full table of possible combinations is as follows:

| Partial | Rules present | Result             |
| ------- | --------------  | --------------- |
| False   | ALL                 | SATISFIED      |
| False   | SOME             | PARTIAL         |
| False   | NONE             | UNSATISFIED |
| True    | ALL                 | PARTIAL         |
| True    | SOME             | PARTIAL         |
| True    | NONE             | UNSATISFIED |